### PR TITLE
Msb/revert java 11

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,12 +17,11 @@ jobs:
       NEG5_ENVIRONMENT: CI
       NEG5_JWT: ${{ secrets.NEG5JWT }}
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Java 11
-      uses: actions/setup-java@v2
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
       with:
-        distribution: 'temurin'
-        java-version: '11'
+        java-version: 1.8
     - name: Build and Unit Test
       run: mvn -B package --file pom.xml
     - name: Spotless Check

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM maven:3.8.6-eclipse-temurin-11-alpine as build
+FROM maven:3.6.3-jdk-8 as build
 COPY . .
 RUN mvn -B -f pom.xml clean package -DskipTests
 
-FROM eclipse-temurin:11-alpine
+FROM amazoncorretto:8u352-al2
 COPY --from=build ./service/target/neg5.service-1.0-SNAPSHOT-jar-with-dependencies.jar .
 COPY --from=build ./service/target/newrelic/newrelic.jar .
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ### Getting started
 1. Fork and clone the repository.
-2. Ensure you have the Java 11 JDK installed on your machine. If you don't, you can use
-download the appropriate [Temurin distribution.](https://adoptium.net/temurin/releases/?version=11)
+2. Ensure you have the Java 8 JDK installed on your machine. If you don't, you can use
+download the appropriate [Temurin distribution.](https://adoptium.net/temurin/releases/?version=8)
 for your operating system. Once installed, you'll need to update your $JAVA_HOME environment variable and update your IDE to compile and run with Java 11.
 3. Install [Maven](https://maven.apache.org/). You'll need it to build the code.
 4. Install [Docker](https://www.docker.com/). You'll need it to run your database.

--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -14,6 +14,12 @@
 
     <artifactId>gson</artifactId>
 
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.inject</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.0</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -71,8 +71,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.0</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -110,7 +110,7 @@
                 <artifactId>heroku-maven-plugin</artifactId>
                 <version>3.0.6</version>
                 <configuration>
-                    <jdkVersion>11</jdkVersion>
+                    <jdkVersion>8</jdkVersion>
                     <appName>spark-neg5-api</appName>
                     <processTypes>
                         <web>java -Xmx256m -javaagent:./target/newrelic/newrelic.jar -jar ./target/neg5.service-1.0-SNAPSHOT-jar-with-dependencies.jar</web>


### PR DESCRIPTION
The Java 11 upgrade caused a decent increase in memory (50 MB or so) usage on the Heroku app. It's honestly not that big of a jump, but since the max memory on the current dyno is 512 MB, that put us dangerously close to the limit. 

Come back and apply this PR again: https://github.com/mostafab/neg5.service/pull/78 when the app moves off Heroku or the base memory is increased.